### PR TITLE
mongodb - sort by relevance

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -83,7 +83,12 @@ module.exports = function(db) {
 			}
 		}
 
-		db.client.collection('search' + key).find(searchQuery, {limit: parseInt(limit, 10), fields:{_id: 0, id: 1}}).toArray(function(err, results) {
+		db.client.collection('search' + key).aggregate([
+			{$match: searchQuery},
+			{$sort: {score: {$meta: 'textScore'}}},
+			{$limit: parseInt(limit, 10)},
+			{$project: {_id: 0, id: 1}}
+		]).toArray(function(err, results) {
 			if (err) {
 				return callback(err);
 			}


### PR DESCRIPTION
It appears that the redis version already does this.

MongoDB was giving scores of 0.5 to unsorted results and 2.0 to the sorted results. No major speed change on a 800k post database.