### PR TITLE
support ngram for better Asia language search

### DIFF
--- a/lib/dbsearch.js
+++ b/lib/dbsearch.js
@@ -413,6 +413,9 @@ async function getGlobalAndPluginData() {
 		categories.buildForSelectAll(['value', 'text']),
 	]);
 
+	if (nconf.get('database') === 'mongo' && await searchModule.isPsmDb()) {
+		languageLookup.ngram = 'ngram(Only support in Percona Server for Mongodb';
+	}
 	const languageSupported = nconf.get('database') === 'mongo' || nconf.get('database') === 'postgres';
 	const languages = Object.keys(languageLookup).map(function (code) {
 		return { name: languageLookup[code], value: code, selected: false };

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -113,3 +113,8 @@ exports.searchRemove = async function (key, ids) {
 
 	await db.client.collection('search' + key).removeMany({ _id: { $in: ids } });
 };
+
+exports.isPsmDb = async function () {
+	const buildInfo = await db.client.command({ buildInfo: 1 });
+	return !!buildInfo.psmdbVersion;
+};


### PR DESCRIPTION
Percona Server for MongoDB supports "ngram" search engine, which is useful for languages as Korean, Chinese, or Japanese.
This cannot be used in the original version of MongoDB.
<https://www.percona.com/doc/percona-server-for-mongodb/LATEST/ngram-full-text-search.html>