### PR TITLE
fix: broken chat search on redis

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -73,11 +73,16 @@ exports.chat.search = async (data, limit) => {
 	const query = {
 		matchWords: data.matchWords,
 		query: {
-			roomId: data.roomId,
-			uid: data.uid,
 			content: data.content,
 		},
 	};
+	['roomId', 'uid'].forEach((prop) => {
+		if (data.hasOwnProperty(prop)) {
+			if (Array.isArray(data[prop]) && data[prop].filter(Boolean).length) {
+				query.query[prop] = data[prop].filter(Boolean);
+			}
+		}
+	});
 
 	return await db.chatSearch.query(query, 0, limit - 1);
 };


### PR DESCRIPTION
Redisearch docs indicate that whatever is passed in is evaluated against index data.
Therefore, even if uid is passed in and is falsy, it is still evaluated and does not match any indexed data.

This commit updates the `roomId` and `uid` properties so that they must be arrays containing items, similarly to how the postgres method handles values.
