### PR TITLE
Configurable MongoDB read preference for search reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,10 @@ A Plugin that lets users search posts and topics
 
     npm install nodebb-plugin-dbsearch
 
+## MongoDB read preference (replica set deployments)
 
+When the plugin is running on MongoDB, the ACP page exposes a **MongoDB Read Preference** selector that controls where the plugin's read queries (full-text search aggregations and indexed-document counts) are routed. The selector has no effect on the Postgres or Redis backends.
 
+Allowed values match the standard MongoDB read preference modes: `primary` (default), `primaryPreferred`, `secondary`, `secondaryPreferred`, `nearest`. Writes (indexing, removals) always go to the primary regardless of this setting.
+
+The default of `primary` keeps the original behavior. On a replica set, switching to `secondaryPreferred` (or `secondary`) offloads search load from the primary at the cost of slightly stale results due to replication lag — usually unnoticeable for full-text search but worth knowing for workflows that reindex and immediately query. On standalone deployments the driver transparently falls back to the primary, so the setting is a no-op.

--- a/lib/dbsearch.js
+++ b/lib/dbsearch.js
@@ -42,12 +42,20 @@ const languageLookup = {
 
 const defaultPostLimit = 500;
 const defaultTopicLimit = 500;
+const defaultMongoReadPreference = 'primary';
 
 let pluginConfig = {
 	postLimit: defaultPostLimit,
 	topicLimit: defaultTopicLimit,
 	excludeCategories: [],
+	mongoReadPreference: defaultMongoReadPreference,
 };
+
+function applyMongoReadPreference(pref) {
+	if (typeof searchModule.setReadPreference === 'function') {
+		searchModule.setReadPreference(pref);
+	}
+}
 
 const batchSize = 500;
 
@@ -68,10 +76,12 @@ search.init = async function (params) {
 	router.post('/api/admin/plugins/dbsearch/save', params.middleware.applyCSRF, save);
 
 	pluginConfig = await getPluginData();
+	applyMongoReadPreference(pluginConfig.mongoReadPreference);
 	await searchModule.createIndices(convertLanguageName(pluginConfig ? pluginConfig.indexLanguage || 'en' : 'en'));
 
 	pubsub.on('nodebb-plugin-dbsearch:settings:save', (data) => {
 		Object.assign(pluginConfig, data);
+		applyMongoReadPreference(pluginConfig.mongoReadPreference);
 	});
 };
 
@@ -496,10 +506,16 @@ async function renderAdmin(req, res) {
 
 async function save(req, res) {
 	if (utils.isNumber(req.body.postLimit) && utils.isNumber(req.body.topicLimit)) {
+		const allowed = searchModule.VALID_READ_PREFERENCES || [];
+		const mongoReadPreference = allowed.includes(req.body.mongoReadPreference) ?
+			req.body.mongoReadPreference :
+			defaultMongoReadPreference;
+
 		const data = {
 			postLimit: req.body.postLimit,
 			topicLimit: req.body.topicLimit,
 			excludeCategories: JSON.stringify(req.body.excludeCategories || []),
+			mongoReadPreference: mongoReadPreference,
 		};
 
 		await db.setObject('nodebb-plugin-dbsearch', data);
@@ -507,6 +523,7 @@ async function save(req, res) {
 		pluginConfig.postLimit = data.postLimit;
 		pluginConfig.topicLimit = data.topicLimit;
 		pluginConfig.excludeCategories = req.body.excludeCategories || [];
+		pluginConfig.mongoReadPreference = mongoReadPreference;
 		pubsub.publish('nodebb-plugin-dbsearch:settings:save', pluginConfig);
 		res.json('Settings saved!');
 	}
@@ -524,6 +541,7 @@ async function getPluginData() {
 	data.postLimit = data.postLimit || defaultPostLimit;
 	data.topicLimit = data.topicLimit || defaultTopicLimit;
 	data.indexLanguage = data.indexLanguage || 'en';
+	data.mongoReadPreference = data.mongoReadPreference || defaultMongoReadPreference;
 	data.working = parseInt(data.working, 10) || 0;
 
 	try {
@@ -549,6 +567,12 @@ async function getGlobalAndPluginData() {
 
 	plugin.languageSupported = languageSupported;
 	plugin.languages = languages;
+
+	plugin.mongoBackend = nconf.get('database') === 'mongo';
+	plugin.mongoReadPreferences = (searchModule.VALID_READ_PREFERENCES || []).map(value => ({
+		value,
+		selected: value === plugin.mongoReadPreference,
+	}));
 
 	plugin.allCategories = allCategories;
 	plugin.topicCount = parseInt(global.topicCount, 10);

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -4,6 +4,30 @@ const nconf = require.main.require('nconf');
 
 const db = require.main.require('./src/database');
 
+const VALID_READ_PREFERENCES = [
+	'primary',
+	'primaryPreferred',
+	'secondary',
+	'secondaryPreferred',
+	'nearest',
+];
+
+let readPreference = 'primary';
+
+exports.VALID_READ_PREFERENCES = VALID_READ_PREFERENCES;
+
+exports.setReadPreference = function (pref) {
+	if (VALID_READ_PREFERENCES.includes(pref)) {
+		readPreference = pref;
+	} else {
+		readPreference = 'primary';
+	}
+};
+
+function readOptions() {
+	return readPreference === 'primary' ? {} : { readPreference };
+}
+
 function generateIndexName(indexSpec) {
 	return Object.entries(indexSpec)
 		.map(([key, value]) => `${key}_${value}`)
@@ -137,7 +161,7 @@ exports.search = async function (key, data, limit) {
 	aggregate.push({ $limit: parseInt(limit, 10) });
 	aggregate.push({ $project: { _id: 1 } });
 
-	const results = await db.client.collection(`search${key}`).aggregate(aggregate).toArray();
+	const results = await db.client.collection(`search${key}`).aggregate(aggregate, readOptions()).toArray();
 	if (!results || !results.length) {
 		return [];
 	}
@@ -204,7 +228,7 @@ exports.chat.search = async (data, limit) => {
 		{ $sort: { score: { $meta: 'textScore' } } },
 		{ $limit: parseInt(limit, 10) },
 		{ $project: { _id: 1 } },
-	]).toArray();
+	], readOptions()).toArray();
 	if (!results || !results.length) {
 		return [];
 	}
@@ -227,13 +251,13 @@ function buildTextQuery(content, matchWords) {
 }
 
 exports.getIndexedTopicCount = async () => {
-	return await db.client.collection('searchtopic').estimatedDocumentCount();
+	return await db.client.collection('searchtopic').estimatedDocumentCount(readOptions());
 };
 
 exports.getIndexedPostCount = async () => {
-	return await db.client.collection('searchpost').estimatedDocumentCount();
+	return await db.client.collection('searchpost').estimatedDocumentCount(readOptions());
 };
 
 exports.getIndexedChatMessageCount = async () => {
-	return await db.client.collection('searchchat').estimatedDocumentCount();
+	return await db.client.collection('searchchat').estimatedDocumentCount(readOptions());
 };

--- a/public/admin.js
+++ b/public/admin.js
@@ -21,6 +21,7 @@ define('admin/plugins/dbsearch', [
 				topicLimit: $('#topicLimit').val(),
 				postLimit: $('#postLimit').val(),
 				excludeCategories: $('#exclude-categories').val(),
+				mongoReadPreference: $('#mongoReadPreference').val(),
 			}, function (data) {
 				if (typeof data === 'string') {
 					settings.toggleSaveSuccess($('#save'));

--- a/templates/admin/plugins/dbsearch.tpl
+++ b/templates/admin/plugins/dbsearch.tpl
@@ -63,6 +63,17 @@
 							<label class="form-label">Post Limit</label>
 							<input id="postLimit" type="text" class="form-control" placeholder="Number of posts to return" value="{postLimit}">
 						</div>
+
+						<!-- IF mongoBackend -->
+						<div class="mb-3">
+							<label class="form-label">MongoDB Read Preference <i class="fa fa-circle-question" title="Routes search read queries (text search and indexed-document counts) to the chosen replica set member. secondaryPreferred can offload search load from the primary on replica set deployments; results may be slightly stale due to replication lag. Has no effect on standalone deployments." data-bs-toggle="tooltip"></i></label>
+							<select class="form-select" id="mongoReadPreference">
+								<!-- BEGIN mongoReadPreferences -->
+								<option value="{mongoReadPreferences.value}" <!-- IF mongoReadPreferences.selected -->selected<!-- ENDIF mongoReadPreferences.selected -->>{mongoReadPreferences.value}</option>
+								<!-- END mongoReadPreferences -->
+							</select>
+						</div>
+						<!-- ENDIF mongoBackend -->
 					</div>
 
 					<div class="col-6">


### PR DESCRIPTION
## Summary

Adds an ACP setting that routes the plugin's MongoDB read queries through a configurable [read preference](https://www.mongodb.com/docs/manual/core/read-preference/). The default is `primary`, so existing deployments are unchanged.

On replica sets, switching to `secondaryPreferred` (or `secondary`) offloads search load — full-text `$text` aggregations are CPU-heavy — from the primary. On standalone deployments the driver transparently falls back to the primary, so the option is a no-op there. Postgres and Redis backends are unaffected (the setter doesn't exist on those modules and the ACP control is hidden).

Writes (indexing, removals) always target the primary regardless of the setting.

## Allowed values

The standard MongoDB read preference modes: `primary` (default), `primaryPreferred`, `secondary`, `secondaryPreferred`, `nearest`. The save handler rejects anything else and falls back to `primary`.

## What changed

- `lib/mongo.js` — exports `VALID_READ_PREFERENCES` and `setReadPreference()`. The current preference is applied as an option to the two `aggregate()` calls and the three `estimatedDocumentCount()` calls. When the preference is `primary`, an empty options object is passed, so behavior is byte-identical to before for users who don't change the setting.
- `lib/dbsearch.js` — loads `mongoReadPreference` from plugin config, validates it on save, propagates it to the Mongo module on init and via the existing `pubsub` settings broadcast (so multi-instance forums stay in sync).
- `templates/admin/plugins/dbsearch.tpl` — dropdown shown only when the backend is Mongo, with a tooltip describing the tradeoff.
- `public/admin.js` — includes the new field in the save POST.
- `README.md` — documents the setting and its caveats.

## Caveats users should know about

- **Replication lag.** With `secondaryPreferred`, results can be slightly stale (typically a few hundred ms). For full-text search this is rarely user-visible, but workflows that reindex and immediately query may see briefly missing results.
- **Topology assumptions.** Some replica set deployments deliberately keep secondaries off the read path (hidden / delayed members, undersized hardware, restricted ACLs). Defaulting to `primary` and making this opt-in avoids breaking those setups.